### PR TITLE
Handle cases when app gets aborted but does not terminate properly.

### DIFF
--- a/Automation/MSTestX.Console/TestRunner.cs
+++ b/Automation/MSTestX.Console/TestRunner.cs
@@ -222,6 +222,10 @@ namespace MSTestX.Console
                             return msg;
                         }
                     }
+                    catch (EndOfStreamException endofStreamException)
+                    {
+                        throw new Exception("Test run is aborted.", endofStreamException);
+                    }
                     catch (IOException ioException)
                     {
                         var socketException = ioException.InnerException as SocketException;


### PR DESCRIPTION
It can happen that app gets aborted unexpectedly. In that case EndofstreamException is thrown. This fix catches the exception allowing app to terminate completely.