### PR TITLE
Update MSTest.TestFramework to version 2.2.5

### DIFF
--- a/src/MSTestX.Adapter/MSTestX.Adapter.csproj
+++ b/src/MSTestX.Adapter/MSTestX.Adapter.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0" />
     <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Version 2.2.4 currently used has been deprecated as it has critical bugs.

https://www.nuget.org/packages/MSTest.TestFramework/2.2.4