### PR TITLE
CLI: Allow to pass a filter via the CLI

### DIFF
--- a/Automation/MSTestX.Console/Program.cs
+++ b/Automation/MSTestX.Console/Program.cs
@@ -544,15 +544,30 @@ iOs specific (MacOS only):
         private static string MergeTestCaseFilter(string? existingSettingsXml, string filterExpression)
         {
             var xmlDoc = new XmlDocument();
+            const string minimalRunSettings = @"<?xml version=""1.0"" encoding=""utf-8""?><RunSettings />";
+
             if (string.IsNullOrWhiteSpace(existingSettingsXml))
             {
-                xmlDoc.LoadXml(@"<?xml version=""1.0"" encoding=""utf-8""?><RunSettings />");
+                xmlDoc.LoadXml(minimalRunSettings);
             }
             else
             {
-                xmlDoc.LoadXml(existingSettingsXml);
+                try
+                {
+                    xmlDoc.LoadXml(existingSettingsXml);
+                }
+                catch (XmlException ex)
+                {
+                    System.Console.Error.WriteLine("Warning: The specified runsettings content is not valid XML and will be ignored. Details: " + ex.Message);
+                    xmlDoc.LoadXml(minimalRunSettings);
+                }
             }
 
+            if (!string.Equals(xmlDoc.DocumentElement?.Name, "RunSettings", StringComparison.Ordinal))
+            {
+                System.Console.Error.WriteLine("Warning: The specified runsettings content does not have a <RunSettings> root element and will be ignored.");
+                xmlDoc.LoadXml(minimalRunSettings);
+            }
             var runSettings = xmlDoc.SelectSingleNode("RunSettings") ?? xmlDoc.AppendChild(xmlDoc.CreateElement("RunSettings"));
             var runConfiguration = runSettings.SelectSingleNode("RunConfiguration") ?? runSettings.AppendChild(xmlDoc.CreateElement("RunConfiguration"));
             var testCaseFilter = runConfiguration.SelectSingleNode("TestCaseFilter") as XmlElement;

--- a/Automation/MSTestX.Console/Program.cs
+++ b/Automation/MSTestX.Console/Program.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace MSTestX.Console
 {
@@ -49,6 +50,7 @@ namespace MSTestX.Console
     -waitForRemote                      If IP of device isn't known, use waitForRemote to wait for app to ping back on port 38302.
     -logFileName <path>                 TRX Output Filename
     -settings <path>                    MSTest RunSettings xml file
+    -filter, --filter <expression>      MSTest test case filter expression
 
 Android specific (ignored if using remoteIp):
     -deviceid <Device Serial Number>    If more than one device is connected, specifies which device to use
@@ -70,6 +72,11 @@ iOs specific (MacOS only):
             if (arguments.ContainsKey("settings") && File.Exists(arguments["settings"]))
             {
                 settingsXml = File.ReadAllText(arguments["settings"]!);
+            }
+
+            if (arguments.TryGetValue("filter", out var filterExpression) && !string.IsNullOrWhiteSpace(filterExpression))
+            {
+                settingsXml = MergeTestCaseFilter(settingsXml, filterExpression);
             }
 
 
@@ -521,7 +528,7 @@ iOs specific (MacOS only):
                 string? value = null;
                 if (args[i].StartsWith("-"))
                 {
-                    key = args[i].Substring(1);
+                    key = args[i].TrimStart('-');
                     if (i < args.Length - 1 && !args[i + 1].StartsWith("-"))
                     {
                         i++;
@@ -532,6 +539,36 @@ iOs specific (MacOS only):
                     result[key] = value;
             }
             return result;
+        }
+
+        private static string MergeTestCaseFilter(string? existingSettingsXml, string filterExpression)
+        {
+            var xmlDoc = new XmlDocument();
+            if (string.IsNullOrWhiteSpace(existingSettingsXml))
+            {
+                xmlDoc.LoadXml(@"<?xml version=""1.0"" encoding=""utf-8""?><RunSettings />");
+            }
+            else
+            {
+                xmlDoc.LoadXml(existingSettingsXml);
+            }
+
+            var runSettings = xmlDoc.SelectSingleNode("RunSettings") ?? xmlDoc.AppendChild(xmlDoc.CreateElement("RunSettings"));
+            var runConfiguration = runSettings.SelectSingleNode("RunConfiguration") ?? runSettings.AppendChild(xmlDoc.CreateElement("RunConfiguration"));
+            var testCaseFilter = runConfiguration.SelectSingleNode("TestCaseFilter") as XmlElement;
+            if (testCaseFilter == null)
+            {
+                testCaseFilter = xmlDoc.CreateElement("TestCaseFilter");
+                runConfiguration.AppendChild(testCaseFilter);
+            }
+
+            testCaseFilter.InnerText = filterExpression;
+
+            using var sw = new StringWriter();
+            using var xw = XmlWriter.Create(sw, new XmlWriterSettings { OmitXmlDeclaration = false });
+            xmlDoc.Save(xw);
+            xw.Flush();
+            return sw.ToString();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ MSTestX.Console -remoteIp 127.0.0.1:38300
 ```
 ### Other parameters
  - `-logFileName <path to file>` : The path of the TRX file that gets generated (defaults to current date/time).
+ - `-filter <expression>` or `--filter <expression>` : MSTest test case filter expression, for example `TestCategory=Smoke` or `FullyQualifiedName~MyNamespace`.
  - `-settings <path to file>` : Path to an XML runsettings file. See [Configure unit tests by using a .runsettings file](https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022) for details.
  - `-deviceid <Android Device Serial Number>`    Android: If more than one device is connected, specifies which device to use
  - `-device <uuid|ecid|serial_number|udid|name|dns_name>`   iOS: The identifier, ECID, serial number, UDID, user-provided name, or DNS name of the device, if more than one device is connected.


### PR DESCRIPTION
The runner already supports the filtering via runsettings, yet to make it easier for usersin the CLI we add a new --filter parameter that will allow to filter the tests.

The code will get the filter form the command line and will update the in memory runsettings that are later sent to the runner. This is the smallest change needed to allow to add a filter without having to update the runsettings file.