### PR TITLE
cli: Make remote runners skip Android device discovery

### DIFF
--- a/Automation/MSTestX.Console.Tests/MSTestX.Console.Tests.csproj
+++ b/Automation/MSTestX.Console.Tests/MSTestX.Console.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MSTestX.Console/MSTestX.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Automation/MSTestX.Console.Tests/ProgramTests.cs
+++ b/Automation/MSTestX.Console.Tests/ProgramTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace MSTestX.Console.Tests;
+
+[TestClass]
+public class ProgramTests
+{
+    [TestMethod]
+    public void GetLaunchMode_UsesRemoteAdapter_WhenRemoteIpIsProvided()
+    {
+        var arguments = new Dictionary<string, string?>
+        {
+            ["remoteIp"] = "127.0.0.1:38300"
+        };
+
+        Assert.AreEqual(LaunchMode.RemoteAdapter, Program.GetLaunchMode(arguments));
+    }
+
+    [TestMethod]
+    public void GetLaunchMode_UsesRemoteAdapter_WhenWaitForRemoteIsProvided()
+    {
+        var arguments = new Dictionary<string, string?>
+        {
+            ["waitForRemote"] = null
+        };
+
+        Assert.AreEqual(LaunchMode.RemoteAdapter, Program.GetLaunchMode(arguments));
+    }
+
+    [TestMethod]
+    public void GetLaunchMode_PrefersRemoteAdapter_OverAppPath()
+    {
+        var arguments = new Dictionary<string, string?>
+        {
+            ["remoteIp"] = "127.0.0.1:38300",
+            ["apppath"] = "/tmp/Test.app"
+        };
+
+        Assert.AreEqual(LaunchMode.RemoteAdapter, Program.GetLaunchMode(arguments));
+    }
+
+    [TestMethod]
+    public void GetLaunchMode_UsesAppleApp_WhenAppPathIsProvidedWithoutRemoteArguments()
+    {
+        var arguments = new Dictionary<string, string?>
+        {
+            ["apppath"] = "/tmp/Test.app"
+        };
+
+        Assert.AreEqual(LaunchMode.AppleApp, Program.GetLaunchMode(arguments));
+    }
+
+    [TestMethod]
+    public void GetLaunchMode_DefaultsToAndroidAdb_WhenNoRemoteOrAppleArgumentsAreProvided()
+    {
+        var arguments = new Dictionary<string, string?>();
+
+        Assert.AreEqual(LaunchMode.AndroidAdb, Program.GetLaunchMode(arguments));
+    }
+}

--- a/Automation/MSTestX.Console/LaunchMode.cs
+++ b/Automation/MSTestX.Console/LaunchMode.cs
@@ -1,0 +1,9 @@
+namespace MSTestX.Console
+{
+    internal enum LaunchMode
+    {
+        RemoteAdapter,
+        AppleApp,
+        AndroidAdb
+    }
+}

--- a/Automation/MSTestX.Console/Program.cs
+++ b/Automation/MSTestX.Console/Program.cs
@@ -31,6 +31,17 @@ namespace MSTestX.Console
         private static CancellationTokenSource? processExitCancellationTokenSource;
         private static TaskCompletionSource<int> testRunCompleted = new TaskCompletionSource<int>();
 
+        internal static LaunchMode GetLaunchMode(Dictionary<string, string?> arguments)
+        {
+            if (arguments.ContainsKey("remoteIp") || arguments.ContainsKey("waitForRemote"))
+                return LaunchMode.RemoteAdapter;
+
+            if (arguments.ContainsKey("apppath"))
+                return LaunchMode.AppleApp;
+
+            return LaunchMode.AndroidAdb;
+        }
+
         static async Task Main(string[] args)
         {
             if (args.Length == 0 || args[0] == "/?" || args[0] == "-?" || args[0] == "?")
@@ -139,97 +150,109 @@ iOs specific (MacOS only):
             if (arguments.ContainsKey("logFileName"))
                 outputFilename = arguments["logFileName"];
 
-            if (testAdapterEndpoint != null)
+            switch (GetLaunchMode(arguments))
             {
-                if (string.IsNullOrEmpty(outputFilename))
+                case LaunchMode.RemoteAdapter:
                 {
-                    string defaultFilename = DateTime.Now.ToString("yyyy-MM-dd_HH_mm_ss");
-                    outputFilename = Path.Combine(System.Environment.CurrentDirectory, defaultFilename + ".trx");
-                }
-                await OnApplicationLaunched(testAdapterEndpoint);
-            }
-            if(arguments.ContainsKey("apppath")) // iOS app
-            {
-                if (!OperatingSystem.IsMacOS())
-                {
-                    System.Console.WriteLine("iOS apps much be launch from a Mac");
-                    testRunCompleted.TrySetResult(1);
-                    return;
-                }
-                var devices = await devicectl.GetConnectedAppleDevicesAsync();
-#if DEBUG
-                System.Console.WriteLine("Connected devices: ");
-                foreach (var d in devices.Result.Devices)
-                {
-                    System.Console.WriteLine($"{d.DeviceProperties.Name} ({d.Identifier}) : {d.HardwareProperties.DeviceType} {d.HardwareProperties.CpuType.Name} {d.DeviceProperties.OsVersionNumber}");
-                }
-#endif
-                string? device = arguments.ContainsKey("device") ? arguments["device"] : null;
-                if (device is null && devices.Result.Devices.Length == 1)
-                {
-                    device = devices.Result.Devices[0].Identifier;
-                }
-                if (string.IsNullOrEmpty(device))
-                {
-                    if (devices.Result.Devices.Length == 0)
-                        System.Console.WriteLine("No devices found");
-                    else
+                    if (testAdapterEndpoint == null)
                     {
-                        System.Console.WriteLine("Device parameter '-device <uuid>' missing and multiple devices connected:");
-                        foreach (var d in devices.Result.Devices)
-                        {
-                            System.Console.WriteLine($"    - {d.Identifier} ({d.DeviceProperties.Name} - {d.HardwareProperties.MarketingName}. OS version: {d.DeviceProperties.OsVersionNumber})");
-                        }
+                        testRunCompleted.TrySetResult(1);
+                        return;
                     }
 
-                    testRunCompleted.TrySetResult(1);
+                    if (string.IsNullOrEmpty(outputFilename))
+                    {
+                        string defaultFilename = DateTime.Now.ToString("yyyy-MM-dd_HH_mm_ss");
+                        outputFilename = Path.Combine(System.Environment.CurrentDirectory, defaultFilename + ".trx");
+                    }
+                    await OnApplicationLaunched(testAdapterEndpoint);
                     return;
                 }
-                var details = await devicectl.GetDeviceDetails(device);
-                var apppath = arguments["apppath"];
-                if (!Directory.Exists(apppath) && !File.Exists(apppath))
+
+                case LaunchMode.AppleApp:
                 {
-                    System.Console.WriteLine("File not found: " + apppath);
-                    testRunCompleted.TrySetResult(1);
+                    if (!OperatingSystem.IsMacOS())
+                    {
+                        System.Console.WriteLine("iOS apps much be launch from a Mac");
+                        testRunCompleted.TrySetResult(1);
+                        return;
+                    }
+                    var devices = await devicectl.GetConnectedAppleDevicesAsync();
+#if DEBUG
+                    System.Console.WriteLine("Connected devices: ");
+                    foreach (var d in devices.Result.Devices)
+                    {
+                        System.Console.WriteLine($"{d.DeviceProperties.Name} ({d.Identifier}) : {d.HardwareProperties.DeviceType} {d.HardwareProperties.CpuType.Name} {d.DeviceProperties.OsVersionNumber}");
+                    }
+#endif
+                    string? device = arguments.ContainsKey("device") ? arguments["device"] : null;
+                    if (device is null && devices.Result.Devices.Length == 1)
+                    {
+                        device = devices.Result.Devices[0].Identifier;
+                    }
+                    if (string.IsNullOrEmpty(device))
+                    {
+                        if (devices.Result.Devices.Length == 0)
+                            System.Console.WriteLine("No devices found");
+                        else
+                        {
+                            System.Console.WriteLine("Device parameter '-device <uuid>' missing and multiple devices connected:");
+                            foreach (var d in devices.Result.Devices)
+                            {
+                                System.Console.WriteLine($"    - {d.Identifier} ({d.DeviceProperties.Name} - {d.HardwareProperties.MarketingName}. OS version: {d.DeviceProperties.OsVersionNumber})");
+                            }
+                        }
+
+                        testRunCompleted.TrySetResult(1);
+                        return;
+                    }
+                    var details = await devicectl.GetDeviceDetails(device);
+                    var apppath = arguments["apppath"];
+                    if (!Directory.Exists(apppath) && !File.Exists(apppath))
+                    {
+                        System.Console.WriteLine("File not found: " + apppath);
+                        testRunCompleted.TrySetResult(1);
+                        return;
+                    }
+                    System.Console.WriteLine("Installing app...");
+                    var bundleId = await devicectl.InstallApp(device, apppath);
+                    System.Console.WriteLine($"App {bundleId} installed");
+
+                    if (string.IsNullOrEmpty(outputFilename))
+                    {
+                        string defaultFilename = DateTime.Now.ToString("yyyy-MM-dd_HH_mm_ss");
+                        outputFilename = Path.Combine(System.Environment.CurrentDirectory, defaultFilename + ".trx");
+                    }
+
+                    // Set up port forwarding using "mobiledevice"
+                    MobileDevice tunnel;
+                    try
+                    {
+                        tunnel = await MobileDevice.CreateTunnelAsync(38300, 38300, details.Result.HardwareProperties.Udid);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        System.Console.WriteLine("Failed to open tunnel: " + ex.Message);
+                        testRunCompleted.TrySetResult(1);
+                        return;
+                    }
+                    tunnel.Exited += (s, e) => { testRunCompleted.TrySetResult(1); System.Console.WriteLine("Tunnel process exited."); };
+
+                    CancellationTokenSource closeAppToken = new CancellationTokenSource();
+                    closeAppToken.Token.Register(t => tunnel.Dispose(), null);
+                    var appTask = devicectl.LaunchApp(device, bundleId, "--TestAdapterPort 38300 --AutoExit True", outputFilename.Replace(".trx", ".log"), closeAppToken.Token);
+                    await OnApplicationLaunched(System.Net.IPEndPoint.Parse("127.0.0.1:38300"));
+                    GC.KeepAlive(tunnel);
+                    closeAppToken.Cancel();
+                    testRunCompleted.TrySetResult(0);
                     return;
                 }
-                System.Console.WriteLine("Installing app...");
-                var bundleId = await devicectl.InstallApp(device, apppath);
-                System.Console.WriteLine($"App {bundleId} installed");
 
-                if (string.IsNullOrEmpty(outputFilename))
+                default:
                 {
-                    string defaultFilename = DateTime.Now.ToString("yyyy-MM-dd_HH_mm_ss");
-                    outputFilename = Path.Combine(System.Environment.CurrentDirectory, defaultFilename + ".trx");
-                }
-
-                // Set up port forwarding using "mobiledevice"
-                MobileDevice tunnel;
-                try
-                {
-                    tunnel = await MobileDevice.CreateTunnelAsync(38300, 38300, details.Result.HardwareProperties.Udid);
-                }
-                catch (System.Exception ex)
-                {
-                    System.Console.WriteLine("Failed to open tunnel: " + ex.Message);
-                    testRunCompleted.TrySetResult(1);
-                    return;
-                }
-                tunnel.Exited += (s, e) => { testRunCompleted.TrySetResult(1); System.Console.WriteLine("Tunnel process exited."); };
-
-                CancellationTokenSource closeAppToken = new CancellationTokenSource();
-                closeAppToken.Token.Register(t => tunnel.Dispose(), null);
-                var appTask = devicectl.LaunchApp(device, bundleId, "--TestAdapterPort 38300 --AutoExit True", outputFilename.Replace(".trx", ".log"), closeAppToken.Token);
-                await OnApplicationLaunched(System.Net.IPEndPoint.Parse("127.0.0.1:38300"));
-                GC.KeepAlive(tunnel);
-                closeAppToken.Cancel();
-                testRunCompleted.TrySetResult(0);
-            }
-            else
-            {
-                // Launch Android android app
-                client = new AdbClient();
-                var devices = await client.GetDevicesAsync();
+                    // Launch Android android app
+                    client = new AdbClient();
+                    var devices = await client.GetDevicesAsync();
                 if (!devices.Any())
                 {
                     System.Console.WriteLine("No devices connected to ADB");
@@ -377,7 +400,9 @@ iOs specific (MacOS only):
                         await device.LaunchApp(apk_id, activityName, new Dictionary<string, object>() { { "TestAdapterPort", 38300 } });
                     }
                 }
-                
+
+                    return;
+                }
             }
         }
 

--- a/Automation/MSTestX.Console/Properties/AssemblyInfo.cs
+++ b/Automation/MSTestX.Console/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.18.0.0")]
 [assembly: AssemblyFileVersion("0.18.0.0")]
+
+[assembly: InternalsVisibleTo("MSTestX.Console.Tests")]


### PR DESCRIPTION
Handle MSTestX.Console launch modes as mutually exclusive paths.

The previous flow handled remoteIp, but then continued into the platform-specific launch logic. When no apppath was supplied, the runner fell through to the Android branch, created an AdbClient, and aborted with "No devices connected to ADB" even though a remote test adapter was already running.

This change introduces an explicit LaunchMode selection for remote adapter, Apple app deployment, and Android ADB execution. RunTest now switches on that mode so remoteIp and waitForRemote stop after the adapter-driven path instead of falling into later branches.

A new MSTestX.Console.Tests project covers the launch mode selection. The tests verify that remoteIp and waitForRemote choose the remote adapter path, that remote execution takes precedence over apppath, and that Apple and Android fallback selection still work as expected.

The test project also uses InternalsVisibleTo to validate the internal launch mode helper without widening the public surface area.