### PR TITLE
catalyst: Ensure that running catalyst tests behaves the same way as ios

### DIFF
--- a/Automation/MSTestX.Console.Tests/ProgramTests.cs
+++ b/Automation/MSTestX.Console.Tests/ProgramTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System;
 using System.Collections.Generic;
 
 namespace MSTestX.Console.Tests;
@@ -57,5 +59,27 @@ public class ProgramTests
         var arguments = new Dictionary<string, string?>();
 
         Assert.AreEqual(LaunchMode.AndroidAdb, Program.GetLaunchMode(arguments));
+    }
+
+    [TestMethod]
+    public void FormatDuration_FormatsSubMillisecondDuration()
+    {
+        Assert.AreEqual("[< 1ms]", TimeSpan.Zero.FormatDuration());
+    }
+
+    [TestMethod]
+    public void FormatDuration_FormatsSecondScaleDuration()
+    {
+        Assert.AreEqual("[1s 250ms]", TimeSpan.FromMilliseconds(1250).FormatDuration());
+    }
+
+    [TestMethod]
+    public void GetRedirectedOutcomeLabel_UsesStableLabels()
+    {
+        Assert.AreEqual("PASS", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Passed));
+        Assert.AreEqual("FAIL", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Failed));
+        Assert.AreEqual("SKIP", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Skipped));
+        Assert.AreEqual("NONE", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.None));
+        Assert.AreEqual("NOTFOUND", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.NotFound));
     }
 }

--- a/Automation/MSTestX.Console.Tests/TestRunnerTests.cs
+++ b/Automation/MSTestX.Console.Tests/TestRunnerTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace MSTestX.Console.Tests;
+
+[TestClass]
+public class TestRunnerTests
+{
+    [TestMethod]
+    public void ShouldWriteTestResult_ReturnsTrue_ForTopLevelResult()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteTestResult(Guid.Empty, isOutputRedirected: false));
+        Assert.IsTrue(TestRunner.ShouldWriteTestResult(Guid.Empty, isOutputRedirected: true));
+    }
+
+    [TestMethod]
+    public void ShouldWriteRunningTest_ReturnsTrue_ForTopLevelResult_WhenOutputIsInteractive()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteRunningTest(Guid.Empty, isOutputRedirected: false));
+    }
+
+    [TestMethod]
+    public void ShouldWriteRunningTest_ReturnsFalse_ForTopLevelResult_WhenOutputIsRedirected()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteRunningTest(Guid.Empty, isOutputRedirected: true));
+    }
+
+    [TestMethod]
+    public void ShouldWriteTestResult_ReturnsTrue_ForChildResult_WhenOutputIsInteractive()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteTestResult(Guid.NewGuid(), isOutputRedirected: false));
+    }
+
+    [TestMethod]
+    public void ShouldWriteTestResult_ReturnsFalse_ForChildResult_WhenOutputIsRedirected()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteTestResult(Guid.NewGuid(), isOutputRedirected: true));
+    }
+
+    [TestMethod]
+    public void ShouldWriteRunningTest_ReturnsTrue_ForChildResult_WhenOutputIsInteractive()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteRunningTest(Guid.NewGuid(), isOutputRedirected: false));
+    }
+
+    [TestMethod]
+    public void ShouldWriteRunningTest_ReturnsFalse_ForChildResult_WhenOutputIsRedirected()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteRunningTest(Guid.NewGuid(), isOutputRedirected: true));
+    }
+
+    [TestMethod]
+    public void ShouldWriteRunningTest_ReturnsFalse_ForRedirectedOutput_RegardlessOfParentExecId()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteRunningTest(Guid.Empty, isOutputRedirected: true));
+        Assert.IsFalse(TestRunner.ShouldWriteRunningTest(Guid.NewGuid(), isOutputRedirected: true));
+    }
+
+    [TestMethod]
+    public void ShouldWriteFailureDetails_ReturnsTrue_ForTopLevelFailureWithMessage()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: false, "boom"));
+        Assert.IsTrue(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: true, "boom"));
+    }
+
+    [TestMethod]
+    public void ShouldWriteFailureDetails_ReturnsTrue_ForChildFailureWithMessage_WhenOutputIsInteractive()
+    {
+        Assert.IsTrue(TestRunner.ShouldWriteFailureDetails(Guid.NewGuid(), isOutputRedirected: false, "boom"));
+    }
+
+    [TestMethod]
+    public void ShouldWriteFailureDetails_ReturnsFalse_ForChildFailureWithMessage_WhenOutputIsRedirected()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteFailureDetails(Guid.NewGuid(), isOutputRedirected: true, "boom"));
+    }
+
+    [TestMethod]
+    public void ShouldWriteFailureDetails_ReturnsFalse_WhenFailureMessageIsMissing()
+    {
+        Assert.IsFalse(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: false, null));
+        Assert.IsFalse(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: false, string.Empty));
+        Assert.IsFalse(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: true, null));
+        Assert.IsFalse(TestRunner.ShouldWriteFailureDetails(Guid.Empty, isOutputRedirected: true, string.Empty));
+    }
+
+    [TestMethod]
+    public void GetRedirectedOutcomeLabel_UsesStableLabels()
+    {
+        Assert.AreEqual("PASS", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Passed));
+        Assert.AreEqual("FAIL", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Failed));
+        Assert.AreEqual("SKIP", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.Skipped));
+        Assert.AreEqual("NONE", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.None));
+    }
+
+    [TestMethod]
+    public void GetRedirectedOutcomeLabel_PreservesNonPassFailOutcomeNames()
+    {
+        Assert.AreEqual("NOTFOUND", TestRunner.GetRedirectedOutcomeLabel(TestOutcome.NotFound));
+    }
+
+    [TestMethod]
+    public void FormatRedirectedRunningTestLine_UsesRunPrefix()
+    {
+        Assert.AreEqual("RUN  Sample.Test", TestRunner.FormatRedirectedRunningTestLine("Sample.Test"));
+    }
+
+    [TestMethod]
+    public void FormatRedirectedResultLine_UsesStableRedirectedFormat()
+    {
+        Assert.AreEqual("FAIL Sample.Test [1s 250ms]", TestRunner.FormatRedirectedResultLine(TestOutcome.Failed, "Sample.Test", TimeSpan.FromMilliseconds(1250)));
+    }
+
+    [TestMethod]
+    public void FormatDuration_FormatsSubMillisecondDuration()
+    {
+        Assert.AreEqual("[< 1ms]", TimeSpan.Zero.FormatDuration());
+    }
+
+    [TestMethod]
+    public void FormatDuration_FormatsSecondScaleDuration()
+    {
+        Assert.AreEqual("[1s 250ms]", TimeSpan.FromMilliseconds(1250).FormatDuration());
+    }
+}

--- a/Automation/MSTestX.Console/MSTestX.Console.csproj
+++ b/Automation/MSTestX.Console/MSTestX.Console.csproj
@@ -12,7 +12,6 @@
     <PackageOutputPath>../../nupkg</PackageOutputPath>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Version>0.41.0</Version>
-    <LangVersion>9.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>bin\</OutputPath>
     <Authors>Morten Nielsen</Authors>

--- a/Automation/MSTestX.Console/TestRunner.cs
+++ b/Automation/MSTestX.Console/TestRunner.cs
@@ -19,6 +19,44 @@ namespace MSTestX.Console
         private SocketCommunicationManager socket;
         private System.Net.IPEndPoint _endpoint;
 
+        internal static string GetRedirectedOutcomeLabel(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome outcome)
+        {
+            return outcome switch
+            {
+                Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed => "PASS",
+                Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Skipped => "SKIP",
+                Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed => "FAIL",
+                _ => outcome.ToString().ToUpperInvariant(),
+            };
+        }
+
+        internal static string FormatRedirectedRunningTestLine(string testName)
+        {
+            return $"RUN  {testName}";
+        }
+
+        internal static string FormatRedirectedResultLine(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome outcome, string testName, TimeSpan duration)
+        {
+            return $"{GetRedirectedOutcomeLabel(outcome)} {testName} {duration.FormatDuration()}";
+        }
+
+        internal static bool ShouldWriteTestResult(Guid parentExecId, bool isOutputRedirected)
+        {
+            return !isOutputRedirected || parentExecId == Guid.Empty;
+        }
+
+        internal static bool ShouldWriteRunningTest(Guid parentExecId, bool isOutputRedirected)
+        {
+            // Start events do not reliably carry ParentExecId for child/data-driven executions,
+            // so redirected RUN lines cannot be matched to top-level tests without producing orphans.
+            return !isOutputRedirected;
+        }
+
+        internal static bool ShouldWriteFailureDetails(Guid parentExecId, bool isOutputRedirected, string testMessage)
+        {
+            return ShouldWriteTestResult(parentExecId, isOutputRedirected) && !string.IsNullOrEmpty(testMessage);
+        }
+
         public TestRunner(System.Net.IPEndPoint endpoint = null)
         {
             _endpoint = endpoint;
@@ -132,12 +170,18 @@ namespace MSTestX.Console
                 }
                 else if (msg.MessageType == MessageType.DataCollectionTestStart)
                 {
-                    if (!System.Console.IsOutputRedirected)
+                    var tcs = JsonDataSerializer.Instance.DeserializePayload<TestCaseStartEventArgs>(msg);
+                    var testName = tcs.GetDisplayName();
+                    var parentExecId = tcs.GetParentExecId();
+                    if (System.Console.IsOutputRedirected)
                     {
-                        var tcs = JsonDataSerializer.Instance.DeserializePayload<TestCaseStartEventArgs>(msg);
-                        var testName = tcs.TestCaseName;
-                        if (string.IsNullOrEmpty(testName))
-                            testName = tcs.TestElement.DisplayName;
+                        if (ShouldWriteRunningTest(parentExecId, isOutputRedirected: true))
+                        {
+                            System.Console.WriteLine(FormatRedirectedRunningTestLine(testName));
+                        }
+                    }
+                    else
+                    {
                         System.Console.Write($"    {testName}");
                     }
                 }
@@ -148,14 +192,11 @@ namespace MSTestX.Console
                 else if (msg.MessageType == MessageType.DataCollectionTestEndResult)
                 {
                     var tr = JsonDataSerializer.Instance.DeserializePayload<Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection.TestResultEventArgs>(msg);
-                    var testName = tr.TestResult.DisplayName;
-                    if (string.IsNullOrEmpty(testName))
-                        testName = tr.TestElement.DisplayName;
+                    var testName = tr.GetDisplayName();
 
                     var outcome = tr.TestResult.Outcome;
 
-                    var parentExecId = tr.TestResult.Properties.Where(t => t.Id == "ParentExecId").Any() ?
-                        tr.TestResult.GetPropertyValue<Guid>(tr.TestResult.Properties.Where(t => t.Id == "ParentExecId").First(), Guid.Empty) : Guid.Empty;
+                    var parentExecId = tr.GetParentExecId();
                     if (outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed)
                     {
                     }
@@ -171,42 +212,39 @@ namespace MSTestX.Console
                     {
                         System.Console.SetCursorPosition(0, System.Console.CursorTop);
                     }
+                    var isOutputRedirected = System.Console.IsOutputRedirected;
                     string testMessage = tr.TestResult?.ErrorMessage;
-                    if (parentExecId == Guid.Empty || !System.Console.IsOutputRedirected)
+                    if (ShouldWriteTestResult(parentExecId, isOutputRedirected))
                     {
-                        switch(outcome)
+                        if (isOutputRedirected)
                         {
-                            case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed:
-                                System.Console.ForegroundColor = ConsoleColor.Green;
-                                System.Console.Write("  √ ");
-                                break;
-                            case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Skipped:
-                                System.Console.ForegroundColor = ConsoleColor.Yellow;
-                                System.Console.Write("  ! ");
-                                break;
-                            case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed:
-                                System.Console.ForegroundColor = ConsoleColor.Red;
-                                System.Console.Write("  X ");
-                                break;
-                            default:
-                                System.Console.Write("    "); break;
+                            System.Console.WriteLine(FormatRedirectedResultLine(outcome, testName, tr.TestResult.Duration));
                         }
-                        System.Console.ResetColor();
-                        System.Console.Write(testName);
-                        var d = tr.TestResult.Duration;
-                        if (d.TotalMilliseconds < 1)
-                            System.Console.WriteLine(" [< 1ms]");
-                        else if (d.TotalSeconds < 1)
-                            System.Console.WriteLine($" [{d.Milliseconds}ms]");
-                        else if (d.TotalMinutes < 1)
-                            System.Console.WriteLine($" [{d.Seconds}s {d.Milliseconds.ToString("0")}ms]");
-                        else if (d.TotalHours < 1)
-                            System.Console.WriteLine($" [{d.Minutes}m {d.Seconds}s {d.Milliseconds.ToString("0")}ms]");
-                        else if (d.TotalDays < 1)
-                            System.Console.WriteLine($" [{d.Hours}h {d.Minutes}m {d.Seconds}s {d.Milliseconds.ToString("0")}ms]");
                         else
-                            System.Console.WriteLine($" [{Math.Floor(d.TotalDays)}d {d.Hours}h {d.Minutes}m {d.Seconds}s {d.Milliseconds.ToString("0")}ms]"); // I sure hope your tests won't ever need this line of code
-                        if (!string.IsNullOrEmpty(testMessage))
+                        {
+                            switch(outcome)
+                            {
+                                case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed:
+                                    System.Console.ForegroundColor = ConsoleColor.Green;
+                                    System.Console.Write("  √ ");
+                                    break;
+                                case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Skipped:
+                                    System.Console.ForegroundColor = ConsoleColor.Yellow;
+                                    System.Console.Write("  ! ");
+                                    break;
+                                case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed:
+                                    System.Console.ForegroundColor = ConsoleColor.Red;
+                                    System.Console.Write("  X ");
+                                    break;
+                                default:
+                                    System.Console.Write("    "); break;
+                            }
+                            System.Console.ResetColor();
+                            System.Console.Write(testName);
+                            System.Console.WriteLine($" {tr.TestResult.Duration.FormatDuration()}");
+                        }
+
+                        if (ShouldWriteFailureDetails(parentExecId, isOutputRedirected, testMessage))
                         {
                             System.Console.ForegroundColor = ConsoleColor.Red;
                             System.Console.WriteLine("  Error Message:");

--- a/Automation/MSTestX.Console/TestRunnerExtensions.cs
+++ b/Automation/MSTestX.Console/TestRunnerExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using System;
+using System.Linq;
+
+namespace MSTestX.Console
+{
+    public static class TestRunnerExtensions
+    {
+        public static string GetDisplayName(this TestCaseStartEventArgs args)
+        {
+            return string.IsNullOrEmpty(args.TestCaseName) ? args.TestElement.DisplayName : args.TestCaseName;
+        }
+
+        public static Guid GetParentExecId(this TestCaseStartEventArgs args)
+        {
+            var parentExecIdProperty = args.TestElement.Properties.FirstOrDefault(t => t.Id == "ParentExecId");
+            return parentExecIdProperty is null ? Guid.Empty : args.TestElement.GetPropertyValue<Guid>(parentExecIdProperty, Guid.Empty);
+        }
+
+        public static string GetDisplayName(this Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection.TestResultEventArgs args)
+        {
+            return string.IsNullOrEmpty(args.TestResult.DisplayName) ? args.TestElement.DisplayName : args.TestResult.DisplayName;
+        }
+
+        public static Guid GetParentExecId(this Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection.TestResultEventArgs args)
+        {
+            var parentExecIdProperty = args.TestResult.Properties.FirstOrDefault(t => t.Id == "ParentExecId");
+            return parentExecIdProperty is null ? Guid.Empty : args.TestResult.GetPropertyValue<Guid>(parentExecIdProperty, Guid.Empty);
+        }
+
+        public static string FormatDuration(this TimeSpan duration)
+        {
+            if (duration.TotalMilliseconds < 1)
+                return "[< 1ms]";
+            if (duration.TotalSeconds < 1)
+                return $"[{duration.Milliseconds}ms]";
+            if (duration.TotalMinutes < 1)
+                return $"[{duration.Seconds}s {duration.Milliseconds:0}ms]";
+            if (duration.TotalHours < 1)
+                return $"[{duration.Minutes}m {duration.Seconds}s {duration.Milliseconds:0}ms]";
+            if (duration.TotalDays < 1)
+                return $"[{duration.Hours}h {duration.Minutes}m {duration.Seconds}s {duration.Milliseconds:0}ms]";
+
+            return $"[{Math.Floor(duration.TotalDays)}d {duration.Hours}h {duration.Minutes}m {duration.Seconds}s {duration.Milliseconds:0}ms]";
+        }
+    }
+}


### PR DESCRIPTION
when using the tool in CI we do not get output to stdout when we run
against a catalyst application. This commit writes to the stoud logs so
that a user that executes the tests in a CI appl like jenkins or githug
actions will get consistent logs.

To achieve that we have:

- Move display name, parent execution id, and duration formatting helpers
  out of TestRunner into shared extension methods so the logic can be
  reused across the console project.

- Keep the redirected output behavior consistent for nested test results
  by preserving child-result filtering for result and failure lines and
  by suppressing redirected RUN lines that cannot be matched reliably
  from start events.

- Add focused unit tests for redirected output decisions and duration
  formatting, and remove the explicit C# language version override now
  that the code uses classic extension methods.
