### PR TITLE
ui: Add run until failure controls

### DIFF
--- a/src/TestAppRunner/TestAppRunner/TestRunner.cs
+++ b/src/TestAppRunner/TestAppRunner/TestRunner.cs
@@ -42,9 +42,16 @@ namespace TestAppRunner
                 cancellationToken.Register(() => token.Cancel());
             settings = runSettings;
             MSTestSettings.PopulateSettings(this);
+            var currentToken = token;
             return System.Threading.Tasks.Task.Run(() => {
-                new TestExecutionManager().RunTests(tests, this, this, token);
-                token = null;
+                try
+                {
+                    new TestExecutionManager().RunTests(tests, this, this, currentToken);
+                }
+                finally
+                {
+                    token = null;
+                }
             });
         }
 

--- a/src/TestAppRunner/TestAppRunner/ViewModels/TestResultGroup.cs
+++ b/src/TestAppRunner/TestAppRunner/ViewModels/TestResultGroup.cs
@@ -46,7 +46,10 @@ namespace TestAppRunner.ViewModels
                     foreach (var p in propertyNames)
                         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"TestResultGroup property notification failed: {ex}");
+                }
             });
         }
 

--- a/src/TestAppRunner/TestAppRunner/ViewModels/TestResultVM.cs
+++ b/src/TestAppRunner/TestAppRunner/ViewModels/TestResultVM.cs
@@ -83,6 +83,16 @@ namespace TestAppRunner.ViewModels
             OnPropertyChanged(nameof(Outcome));
             OnPropertyChanged(nameof(IsInProgress));
         }
+
+        internal void ClearInProgress()
+        {
+            if (!inProgress)
+                return;
+
+            inProgress = false;
+            OnPropertyChanged(nameof(Outcome));
+            OnPropertyChanged(nameof(IsInProgress));
+        }
         public Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome Outcome
         {
             get

--- a/src/TestAppRunner/TestAppRunner/ViewModels/TestRunnerVM.cs
+++ b/src/TestAppRunner/TestAppRunner/ViewModels/TestRunnerVM.cs
@@ -32,6 +32,11 @@ namespace TestAppRunner.ViewModels
         private System.IO.StreamWriter logOutput;
         private TrxWriter trxWriter;
         private TestAdapterConnection connection;
+        private CancellationTokenSource loopTcs;
+        private bool isLoopingUntilFailure;
+        private bool showStopAction;
+        private bool isStopRequested;
+        private int currentIteration;
 
         private static TestRunnerVM _Instance;
 
@@ -161,7 +166,10 @@ namespace TestAppRunner.ViewModels
                             OnPropertyChanged(nameof(SkippedTests));
                         }
                     }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            Logger.Log($"Failed to restore previous test progress: {ex}");
+                        }
                     }
 
 
@@ -226,7 +234,10 @@ namespace TestAppRunner.ViewModels
                     conn.DropTable<TestProgress>();
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to clear saved test progress: {ex}");
+            }
         }
 
         public void DeleteProgress(IEnumerable<TestCase> tests)
@@ -292,12 +303,42 @@ namespace TestAppRunner.ViewModels
 
         private CancellationTokenSource tcs;
 
+        public bool IsLoopingUntilFailure => isLoopingUntilFailure;
+
+        public int CurrentIteration => currentIteration;
+
+        public bool IsBusy => IsRunning || IsLoopingUntilFailure;
+
+        public string RunUntilFailureActionText => showStopAction ? "Stop" : "Run until failure";
+
+        public string LoopIterationText => $"Running until failure · iteration {CurrentIteration}";
+
+        public bool CanInteractWithRunActions => IsInitialized && !isStopRequested;
+
         public event EventHandler<Exception> OnTestRunException;
 
         public void Cancel()
         {
-            tcs?.Cancel();
-            tcs = null;
+            isStopRequested = true;
+            showStopAction = false;
+            OnPropertiesChanged(nameof(CanInteractWithRunActions), nameof(RunUntilFailureActionText));
+            CancelTokenSource(loopTcs);
+            CancelTokenSource(tcs);
+        }
+
+        private static void CancelTokenSource(CancellationTokenSource cancellationTokenSource)
+        {
+            if (cancellationTokenSource is null)
+                return;
+
+            try
+            {
+                cancellationTokenSource.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The run finished and disposed the token source while the UI was handling a stop click.
+            }
         }
 
         public Task<IEnumerable<TestResult>> Run()
@@ -330,11 +371,12 @@ namespace TestAppRunner.ViewModels
 
         public async Task<IEnumerable<TestResult>> Run(IEnumerable<TestCase> testCollection, IRunSettings runSettings)
         {
-            if (IsRunning)
+            if (IsBusy)
                 throw new InvalidOperationException("Can't begin a test run while another is in progress");
             try
             {
-                return await Run_Internal(testCollection, runSettings);
+                var runOutcome = await Run_Internal(testCollection, runSettings, CancellationToken.None);
+                return runOutcome.Results;
             }
             catch(System.Exception ex)
             {
@@ -344,15 +386,105 @@ namespace TestAppRunner.ViewModels
             }
         }
 
-        private async Task<IEnumerable<TestResult>> Run_Internal(IEnumerable<TestCase> testCollection, IRunSettings runSettings)
+        public async Task<IEnumerable<TestResult>> RunUntilFailure(IEnumerable<TestCase> testCollection, IRunSettings runSettings, CancellationToken cancellationToken)
         {
+            if (IsBusy)
+                throw new InvalidOperationException("Can't begin a test run while another is in progress");
+
+            var selectedTests = testCollection?.OrderBy(t => t.FullyQualifiedName).ToArray() ?? Array.Empty<TestCase>();
+            if (!selectedTests.Any())
+                return Enumerable.Empty<TestResult>();
+
+            try
+            {
+                isLoopingUntilFailure = true;
+                currentIteration = 0;
+                loopTcs = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                showStopAction = true;
+                OnPropertyChanged(nameof(IsLoopingUntilFailure));
+                OnPropertyChanged(nameof(CurrentIteration));
+                OnPropertyChanged(nameof(RunUntilFailureActionText));
+                OnPropertyChanged(nameof(LoopIterationText));
+                OnPropertyChanged(nameof(CanInteractWithRunActions));
+
+                List<TestResult> lastResults = new();
+                while (!loopTcs.IsCancellationRequested)
+                {
+                    currentIteration++;
+                    Status = $"Running iteration {currentIteration} until failure...";
+                    OnPropertyChanged(nameof(Status));
+                    OnPropertyChanged(nameof(CurrentIteration));
+                    OnPropertyChanged(nameof(LoopIterationText));
+
+                    var iterationOutcome = await Run_Internal(selectedTests, runSettings ?? Settings, loopTcs.Token, allowTerminate: false);
+                    var iterationResults = iterationOutcome.Results.ToList();
+                    lastResults = iterationResults;
+
+                    if (loopTcs.IsCancellationRequested)
+                    {
+                        Status = $"Run until failure canceled during iteration {currentIteration}.";
+                        OnPropertyChanged(nameof(Status));
+                        break;
+                    }
+
+                    if (iterationOutcome.ExecutionFailed)
+                    {
+                        Status = $"Run until failure stopped after iteration {currentIteration} due to an execution error.";
+                        OnPropertyChanged(nameof(Status));
+                        break;
+                    }
+
+                    var childResults = iterationResults.Where(tt => GetProperty<int>("InnerResultsCount", tt, 0) == 0);
+                    if (childResults.Any(result => result.Outcome == TestOutcome.Failed))
+                    {
+                        Status = $"Run until failure stopped after iteration {currentIteration}.";
+                        OnPropertyChanged(nameof(Status));
+                        break;
+                    }
+                }
+
+                if (Settings.TerminateAfterExecution)
+                {
+                    Terminate();
+                }
+
+                return lastResults;
+            }
+            catch (System.Exception ex)
+            {
+                Logger.Log($"Run until failure failed: {ex.Message}\nStack trace: {ex.StackTrace}");
+                OnTestRunException?.Invoke(this, ex);
+                throw;
+            }
+            finally
+            {
+                loopTcs?.Dispose();
+                loopTcs = null;
+                isLoopingUntilFailure = false;
+                isStopRequested = false;
+                showStopAction = false;
+                OnPropertyChanged(nameof(IsLoopingUntilFailure));
+                OnPropertyChanged(nameof(RunUntilFailureActionText));
+                OnPropertyChanged(nameof(LoopIterationText));
+                OnPropertyChanged(nameof(CanInteractWithRunActions));
+            }
+        }
+
+        public Task<IEnumerable<TestResult>> RunUntilFailure(IEnumerable<TestCase> testCollection, IRunSettings runSettings = null)
+            => RunUntilFailure(testCollection, runSettings ?? Settings, CancellationToken.None);
+
+        private async Task<(IEnumerable<TestResult> Results, bool ExecutionFailed)> Run_Internal(IEnumerable<TestCase> testCollection, IRunSettings runSettings, CancellationToken cancellationToken, bool allowTerminate = true)
+        {
+            var selectedTests = testCollection.OrderBy(tst => tst.FullyQualifiedName).ToArray();
             HostApp?.RaiseTestRunStarted(testCollection);
-            var t = tcs = new CancellationTokenSource();
+            var t = tcs = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            isStopRequested = false;
+            var executionFailed = false;
             Status = $"Running tests...";
             OnPropertyChanged(nameof(Status));
             DiagnosticsInfo = "";
             OnPropertyChanged(nameof(DiagnosticsInfo));
-            foreach (var item in testCollection)
+            foreach (var item in selectedTests)
             {
                 tests[item.Id].Result = null;
             }
@@ -378,14 +510,16 @@ namespace TestAppRunner.ViewModels
                 trxWriter = new TrxWriter(Settings.TrxOutputPath);
             }
             
-            if (testCollection.Count() == Tests.Count())
+            if (selectedTests.Length == Tests.Count())
                 DeleteProgress();
             else
-                DeleteProgress(testCollection);
+                DeleteProgress(selectedTests);
             DateTime start = DateTime.Now;
-            Logger.Log($"STARTING TESTRUN {testCollection.Count()} Tests");
-            var task = testRunner.Run(testCollection.OrderBy(tst => tst.FullyQualifiedName), runSettings, t.Token);
+            Logger.Log($"STARTING TESTRUN {selectedTests.Length} Tests");
+            var task = testRunner.Run(selectedTests, runSettings, t.Token);
+            showStopAction = true;
             OnPropertyChanged(nameof(IsRunning));
+            OnPropertyChanged(nameof(RunUntilFailureActionText));
             try
             {
                 await task;
@@ -401,9 +535,18 @@ namespace TestAppRunner.ViewModels
             }
             catch (System.Exception ex)
             {
+                executionFailed = true;
                 Status = $"Test run failed to run: {ex.Message}";
             }
             DateTime end = DateTime.Now;
+            foreach (var item in selectedTests)
+            {
+                var vmTest = tests[item.Id];
+                if (vmTest.Result is null)
+                {
+                    vmTest.ClearInProgress();
+                }
+            }
             CurrentTestRunning = null;
             OnPropertyChanged(nameof(CurrentTestRunning));
             if (logOutput != null)
@@ -445,16 +588,22 @@ namespace TestAppRunner.ViewModels
             if (Settings.ProgressLogPath != null) DiagnosticsInfo += $"\nLog: {Settings.ProgressLogPath}";
             if (Settings.TrxOutputPath != null) DiagnosticsInfo += $"\nTRX Report: {Settings.TrxOutputPath}";
             OnPropertyChanged(nameof(DiagnosticsInfo));
+            showStopAction = false;
+            isStopRequested = false;
             OnPropertyChanged(nameof(IsRunning));
+            OnPropertyChanged(nameof(RunUntilFailureActionText));
+            OnPropertyChanged(nameof(CanInteractWithRunActions));
             OnPropertyChanged(nameof(Status));
             HostApp?.RaiseTestRunCompleted(results);
 
             Logger.Log($"COMPLETED TESTRUN Total:{childResults.Count()} Failed:{childResults.Where(a => a.Outcome == TestOutcome.Failed).Count()} Passed:{childResults.Where(a => a.Outcome == TestOutcome.Passed).Count()}  Skipped:{childResults.Where(a => a.Outcome == TestOutcome.Skipped).Count()}");
-            if (Settings.TerminateAfterExecution)
+            if (allowTerminate && Settings.TerminateAfterExecution)
             {
                 Terminate();
             }
-            return results;
+            tcs.Dispose();
+            tcs = null;
+            return (results, executionFailed);
         }
 
         private void Terminate()

--- a/src/TestAppRunner/TestAppRunner/ViewModels/VMBase.cs
+++ b/src/TestAppRunner/TestAppRunner/ViewModels/VMBase.cs
@@ -25,7 +25,10 @@ namespace TestAppRunner.ViewModels
                 {
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"PropertyChanged notification failed for '{propertyName}': {ex}");
+                }
             });
         }
 
@@ -38,7 +41,10 @@ namespace TestAppRunner.ViewModels
                     foreach (var propertyName in propertyNames)
                         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"PropertyChanged notification failed: {ex}");
+                }
             });
         }
     }

--- a/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml
@@ -42,6 +42,11 @@
                         <Label Text="{Binding CurrentTestRunning.Test.FullyQualifiedName, Mode=OneWay}" LineBreakMode="MiddleTruncation" FontAttributes="Bold" TextColor="{DynamicResource foregroundColor}" VerticalOptions="Start"/>
                     </StackLayout>
                 </Grid>
+                <Label Text="{Binding LoopIterationText}"
+                       IsVisible="{Binding IsLoopingUntilFailure, Mode=OneWay}"
+                       Margin="20,0,20,10"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource accentColor}" />
                 <Grid BackgroundColor="Gray" HeightRequest="1" />
 
                 <Picker x:Name="picker" SelectedIndexChanged="picker_SelectedIndexChanged" Title="Group By" />
@@ -72,7 +77,10 @@
                 </CollectionView.Footer>
             </CollectionView>
 
-            <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" Grid.Row="3" IsEnabled="{Binding IsInitialized, Mode=OneWay}" />
+            <VerticalStackLayout Grid.Row="3" Spacing="10" Padding="10,0,10,10">
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" IsEnabled="{Binding CanInteractWithRunActions, Mode=OneWay}" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions, Mode=OneWay}" />
+            </VerticalStackLayout>
 
             <Frame x:Name="ErrorPanel" Grid.RowSpan="4" HorizontalOptions="Center" VerticalOptions="Fill"
                   IsVisible="False" BorderColor="{DynamicResource foregroundColor}">

--- a/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml.cs
@@ -57,7 +57,7 @@ namespace TestAppRunner.Views
 
         private async void Button_Clicked(object sender, EventArgs e)
         {
-            if (TestRunnerVM.Instance.IsRunning)
+            if (TestRunnerVM.Instance.IsBusy)
                 TestRunnerVM.Instance.Cancel();
             else
             {
@@ -65,7 +65,28 @@ namespace TestAppRunner.Views
                 {
                     await TestRunnerVM.Instance.Run();
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run command failed: {ex}");
+                }
+            }
+        }
+
+        private async void RunUntilFailureButton_Clicked(object sender, EventArgs e)
+        {
+            if (TestRunnerVM.Instance.IsBusy)
+            {
+                TestRunnerVM.Instance.Cancel();
+                return;
+            }
+
+            try
+            {
+                await TestRunnerVM.Instance.RunUntilFailure(TestRunnerVM.Instance.Tests.Select(t => t.Test));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Run-until-failure command failed: {ex}");
             }
         }
 
@@ -99,13 +120,13 @@ namespace TestAppRunner.Views
 
         private void RunRemaining_Clicked()
         {
-            if (TestRunnerVM.Instance.IsRunning) return;
+            if (TestRunnerVM.Instance.IsBusy) return;
             TestRunnerVM.Instance.RunRemainingTests();
         }
 
         private void RunFailed_Clicked()
         {
-            if (TestRunnerVM.Instance.IsRunning) return;
+            if (TestRunnerVM.Instance.IsBusy) return;
             TestRunnerVM.Instance.RunFailedTests();
         }
 
@@ -179,7 +200,7 @@ namespace TestAppRunner.Views
         }
         private void StopRun_Clicked()
         {
-            if (TestRunnerVM.Instance.IsRunning)
+            if (TestRunnerVM.Instance.IsBusy)
             {
                 TestRunnerVM.Instance.Cancel();
             }

--- a/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml
@@ -38,6 +38,12 @@
                     <ActivityIndicator IsRunning="{Binding CurrentTestRunning, Converter={StaticResource nullToFalseConverter}, Mode=OneWay}" HeightRequest="15" WidthRequest="15" Color="{DynamicResource accentColor}" />
                     <Label Text="{Binding CurrentTestRunning.Test.FullyQualifiedName, Mode=OneWay}" LineBreakMode="MiddleTruncation" FontAttributes="Bold" TextColor="{DynamicResource foregroundColor}" VerticalOptions="Start"/>
                 </StackLayout>
+                <Label x:Name="loopIterationLabel"
+                       Margin="20,0,20,10"
+                       FontAttributes="Bold"
+                       IsVisible="{Binding IsLoopingUntilFailure, Mode=OneWay}"
+                       Text="{Binding LoopIterationText}"
+                       TextColor="{DynamicResource accentColor}" />
                 <Grid BackgroundColor="Gray" HeightRequest="1" />
             </StackLayout>
             <CollectionView x:Name="list" SelectionChanged="list_ItemSelected" Grid.Row="1" SelectionMode="Single">
@@ -62,7 +68,10 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
-            <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" Grid.Row="2" />
+            <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions}" />
+            </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml.cs
@@ -30,18 +30,48 @@ namespace TestAppRunner.Views
             this.tests = tests;
             list.ItemsSource = new List<TestResultGroup>(tests.GroupBy(t => t.ClassName).Select((g, t) => new TestResultGroup(g.Key.StartsWith(tests.Group + ".") ? g.Key.Substring(tests.Group.Length + 1) : g.Key, g)).OrderBy(g=>g.Group));
             currentTestView.BindingContext = TestRunnerVM.Instance;
+            loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
             this.BindingContext = tests;
         }
 
-        private void Button_Clicked(object sender, EventArgs e)
+        private async void Button_Clicked(object sender, EventArgs e)
         {
-            if (TestRunnerVM.Instance.IsRunning)
+            if (TestRunnerVM.Instance.IsBusy)
             {
                 TestRunnerVM.Instance.Cancel();
             }
             else
             {
-                var _ = TestRunnerVM.Instance.Run(tests.Select(t => t.Test));
+                try
+                {
+                    await TestRunnerVM.Instance.Run(tests.Select(t => t.Test));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
+            }
+        }
+
+        private async void RunUntilFailureButton_Clicked(object sender, EventArgs e)
+        {
+            if (TestRunnerVM.Instance.IsBusy)
+            {
+                TestRunnerVM.Instance.Cancel();
+            }
+            else
+            {
+                try
+                {
+                    await TestRunnerVM.Instance.RunUntilFailure(tests.Select(t => t.Test));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run-until-failure command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
             }
         }
 

--- a/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
@@ -29,6 +29,12 @@
 
                     <Label Text="{Binding ClassName}" TextColor="{DynamicResource foregroundColor}" />
                     <ActivityIndicator IsRunning="{Binding IsInProgress}" HeightRequest="15" WidthRequest="15" Color="{DynamicResource accentColor}" />
+                    <Label x:Name="loopIterationLabel"
+                           Margin="0,0,0,10"
+                           FontAttributes="Bold"
+                           IsVisible="{Binding IsLoopingUntilFailure, Mode=OneWay}"
+                           Text="{Binding LoopIterationText}"
+                           TextColor="{DynamicResource accentColor}" />
                     <StackLayout Orientation="Horizontal" IsVisible="{Binding ChildResults, Converter={StaticResource nullToFalseConverter}, ConverterParameter=reverse}">
                         <Label Text="Elapsed time: " FontAttributes="Bold" TextColor="{DynamicResource foregroundColor}" />
                         <Label Text="{Binding Duration}" TextColor="{DynamicResource foregroundColor}" />
@@ -80,7 +86,10 @@
                 </StackLayout>
 
             </ScrollView>
-            <Button Text="Run Test" Grid.Row="2" Clicked="Button_Clicked" />
+            <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
+                <Button Text="Run Test" Clicked="Button_Clicked" />
+                <Button Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" Clicked="RunUntilFailureButton_Clicked" IsEnabled="{Binding CanInteractWithRunActions}" />
+            </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml.cs
@@ -29,13 +29,43 @@ namespace TestAppRunner.Views
 		{
             this.BindingContext = vm;
             InitializeComponent();
+            loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
 		}
 
-        private void Button_Clicked(object sender, EventArgs e)
+        private async void Button_Clicked(object sender, EventArgs e)
         {
-            if (!TestRunnerVM.Instance.IsRunning)
+            if (!TestRunnerVM.Instance.IsBusy)
             {
-                var _ = TestRunnerVM.Instance.Run(new[] { ((TestResultVM)BindingContext).Test });
+                try
+                {
+                    await TestRunnerVM.Instance.Run(new[] { ((TestResultVM)BindingContext).Test });
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
+            }
+        }
+
+        private async void RunUntilFailureButton_Clicked(object sender, EventArgs e)
+        {
+            if (TestRunnerVM.Instance.IsBusy)
+            {
+                TestRunnerVM.Instance.Cancel();
+            }
+            else
+            {
+                try
+                {
+                    await TestRunnerVM.Instance.RunUntilFailure(new[] { ((TestResultVM)BindingContext).Test });
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run-until-failure command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
             }
         }
 

--- a/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml
@@ -39,6 +39,12 @@
                     <ActivityIndicator IsRunning="{Binding CurrentTestRunning, Converter={StaticResource nullToFalseConverter}, Mode=OneWay}" HeightRequest="15" WidthRequest="15" Color="{DynamicResource accentColor}" />
                     <Label Text="{Binding CurrentTestRunning.Test.FullyQualifiedName, Mode=OneWay}" LineBreakMode="MiddleTruncation" FontAttributes="Bold" TextColor="{DynamicResource foregroundColor}" VerticalOptions="Start"/>
                 </StackLayout>
+                <Label x:Name="loopIterationLabel"
+                       Margin="20,0,20,10"
+                       FontAttributes="Bold"
+                       IsVisible="{Binding IsLoopingUntilFailure, Mode=OneWay}"
+                       Text="{Binding LoopIterationText}"
+                       TextColor="{DynamicResource accentColor}" />
                 <Grid BackgroundColor="Gray" HeightRequest="1" />
             </StackLayout>
             <CollectionView x:Name="list" SelectionChanged="list_ItemSelected" ItemsSource="{Binding}" Grid.Row="1" SelectionMode="Single">
@@ -60,7 +66,10 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
-            <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" Grid.Row="2" />
+            <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions}" />
+            </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml.cs
@@ -13,18 +13,48 @@ namespace TestAppRunner.Views
 		{
 			InitializeComponent();
             currentTestView.BindingContext = TestRunnerVM.Instance;
+            loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
             this.BindingContext = testCases;
         }
 
-        private void Button_Clicked(object sender, EventArgs e)
+        private async void Button_Clicked(object sender, EventArgs e)
         {
-            if (TestRunnerVM.Instance.IsRunning)
+            if (TestRunnerVM.Instance.IsBusy)
             {
                 TestRunnerVM.Instance.Cancel();
             }
             else
             {
-                var _ = TestRunnerVM.Instance.Run(((TestResultGroup)BindingContext).Select(t => t.Test));
+                try
+                {
+                    await TestRunnerVM.Instance.Run(((TestResultGroup)BindingContext).Select(t => t.Test));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
+            }
+        }
+
+        private async void RunUntilFailureButton_Clicked(object sender, EventArgs e)
+        {
+            if (TestRunnerVM.Instance.IsBusy)
+            {
+                TestRunnerVM.Instance.Cancel();
+            }
+            else
+            {
+                try
+                {
+                    await TestRunnerVM.Instance.RunUntilFailure(((TestResultGroup)BindingContext).Select(t => t.Test));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Run-until-failure command failed: {ex}");
+                    await DisplayAlert("Test Run Error", ex.Message, "OK");
+                }
             }
         }
 


### PR DESCRIPTION
Add run-until-failure actions across the MAUI test runner pages and
wire them through TestRunnerVM so selected tests can loop until a
failure is observed.

Update the UI to stack the run actions, show loop iteration state,
and keep the stop flow responsive while preventing re-entry during
run teardown.

Harden the runner state cleanup so cancellation clears limbo states,
execution failures stop the loop, auto-terminate is deferred until
after the loop completes, and UI handler exceptions are surfaced
instead of being silently ignored.
