### PR TITLE
ui: Enable selectable test messages

### DIFF
--- a/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
@@ -38,7 +38,13 @@
                     <Label Text="{Binding Properties}" IsVisible="{Binding HasProperties}" TextColor="{DynamicResource foregroundColor}" />
 
                     <Label Text="Messages:" FontAttributes="Bold" FontSize="18" IsVisible="{Binding HasMessages}" TextColor="{DynamicResource foregroundColor}" />
-                    <Label Text="{Binding Messages}" LineBreakMode="WordWrap" IsVisible="{Binding HasMessages}" TextColor="{DynamicResource foregroundColor}" />
+                    <Editor Text="{Binding Messages}"
+                            IsEnabled="False"
+                            IsSpellCheckEnabled="False"
+                            AutoSize="TextChanges"
+                            Margin="0"
+                            IsVisible="{Binding HasMessages}"
+                            TextColor="{DynamicResource foregroundColor}" />
 
                     <Label Text="
                            :" FontAttributes="Bold" FontSize="18" IsVisible="{Binding HasError}" TextColor="{DynamicResource foregroundColor}" />

--- a/src/UnitTests/UnitTests.cs
+++ b/src/UnitTests/UnitTests.cs
@@ -45,6 +45,18 @@ namespace UnitTests
 
         [TestMethod]
         [TestCategory("Synchronous tests")]
+        [Description("Sample test with multiple log lines for message selection")]
+        public void TestWithSelectableMessagesSample()
+        {
+            Assert.IsNotNull(TestContext);
+            TestContext.WriteLine("Selectable message sample line 1.");
+            TestContext.WriteLine("Selectable message sample line 2: 1234567890.");
+            TestContext.WriteLine("Selectable message sample line 3 with symbols !@#$%^&*().");
+            TestContext.WriteLine("Selectable message sample line 4.");
+        }
+
+        [TestMethod]
+        [TestCategory("Synchronous tests")]
         [Description("This test writes out one message then fails")]
         public void TestFailWithMessages()
         {


### PR DESCRIPTION
Replace the Messages label on the test detail page with a read-only
Editor so the output can be selected and copied like the stack
trace.

Add a sample unit test that writes several log lines so the new
behavior is easy to verify in the app.
