### PR TITLE
ui: Fix run button state handling

### DIFF
--- a/src/TestAppRunner/TestAppRunner/ViewModels/TestRunnerVM.cs
+++ b/src/TestAppRunner/TestAppRunner/ViewModels/TestRunnerVM.cs
@@ -191,6 +191,7 @@ namespace TestAppRunner.ViewModels
             Status = $"{tests.Count} tests found.";
             OnPropertyChanged(nameof(Status));
             OnPropertyChanged(nameof(IsInitialized));
+            OnRunActionStateChanged();
         }
 
         private readonly string progressPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "unittest_progress.bin");
@@ -307,13 +308,18 @@ namespace TestAppRunner.ViewModels
 
         public int CurrentIteration => currentIteration;
 
-        public bool IsBusy => IsRunning || IsLoopingUntilFailure;
+        public bool IsBusy => tcs != null || IsLoopingUntilFailure;
 
         public string RunUntilFailureActionText => showStopAction ? "Stop" : "Run until failure";
 
         public string LoopIterationText => $"Running until failure · iteration {CurrentIteration}";
 
-        public bool CanInteractWithRunActions => IsInitialized && !isStopRequested;
+        public bool CanRunTests => IsInitialized && !IsBusy && !isStopRequested;
+
+        public bool CanRunUntilFailure =>
+            IsInitialized &&
+            !isStopRequested &&
+            (!IsBusy || (IsLoopingUntilFailure && showStopAction));
 
         public event EventHandler<Exception> OnTestRunException;
 
@@ -321,9 +327,18 @@ namespace TestAppRunner.ViewModels
         {
             isStopRequested = true;
             showStopAction = false;
-            OnPropertiesChanged(nameof(CanInteractWithRunActions), nameof(RunUntilFailureActionText));
+            OnRunActionStateChanged();
             CancelTokenSource(loopTcs);
             CancelTokenSource(tcs);
+        }
+
+        private void OnRunActionStateChanged()
+        {
+            OnPropertiesChanged(
+                nameof(IsBusy),
+                nameof(CanRunTests),
+                nameof(CanRunUntilFailure),
+                nameof(RunUntilFailureActionText));
         }
 
         private static void CancelTokenSource(CancellationTokenSource cancellationTokenSource)
@@ -403,9 +418,8 @@ namespace TestAppRunner.ViewModels
                 showStopAction = true;
                 OnPropertyChanged(nameof(IsLoopingUntilFailure));
                 OnPropertyChanged(nameof(CurrentIteration));
-                OnPropertyChanged(nameof(RunUntilFailureActionText));
                 OnPropertyChanged(nameof(LoopIterationText));
-                OnPropertyChanged(nameof(CanInteractWithRunActions));
+                OnRunActionStateChanged();
 
                 List<TestResult> lastResults = new();
                 while (!loopTcs.IsCancellationRequested)
@@ -464,9 +478,8 @@ namespace TestAppRunner.ViewModels
                 isStopRequested = false;
                 showStopAction = false;
                 OnPropertyChanged(nameof(IsLoopingUntilFailure));
-                OnPropertyChanged(nameof(RunUntilFailureActionText));
                 OnPropertyChanged(nameof(LoopIterationText));
-                OnPropertyChanged(nameof(CanInteractWithRunActions));
+                OnRunActionStateChanged();
             }
         }
 
@@ -517,9 +530,8 @@ namespace TestAppRunner.ViewModels
             DateTime start = DateTime.Now;
             Logger.Log($"STARTING TESTRUN {selectedTests.Length} Tests");
             var task = testRunner.Run(selectedTests, runSettings, t.Token);
-            showStopAction = true;
             OnPropertyChanged(nameof(IsRunning));
-            OnPropertyChanged(nameof(RunUntilFailureActionText));
+            OnRunActionStateChanged();
             try
             {
                 await task;
@@ -588,11 +600,9 @@ namespace TestAppRunner.ViewModels
             if (Settings.ProgressLogPath != null) DiagnosticsInfo += $"\nLog: {Settings.ProgressLogPath}";
             if (Settings.TrxOutputPath != null) DiagnosticsInfo += $"\nTRX Report: {Settings.TrxOutputPath}";
             OnPropertyChanged(nameof(DiagnosticsInfo));
-            showStopAction = false;
             isStopRequested = false;
             OnPropertyChanged(nameof(IsRunning));
-            OnPropertyChanged(nameof(RunUntilFailureActionText));
-            OnPropertyChanged(nameof(CanInteractWithRunActions));
+            OnRunActionStateChanged();
             OnPropertyChanged(nameof(Status));
             HostApp?.RaiseTestRunCompleted(results);
 

--- a/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/AllTestsPage.xaml
@@ -78,8 +78,8 @@
             </CollectionView>
 
             <VerticalStackLayout Grid.Row="3" Spacing="10" Padding="10,0,10,10">
-                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" IsEnabled="{Binding CanInteractWithRunActions, Mode=OneWay}" />
-                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions, Mode=OneWay}" />
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" IsEnabled="{Binding CanRunTests, Mode=OneWay}" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanRunUntilFailure, Mode=OneWay}" />
             </VerticalStackLayout>
 
             <Frame x:Name="ErrorPanel" Grid.RowSpan="4" HorizontalOptions="Center" VerticalOptions="Fill"

--- a/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml
@@ -69,8 +69,8 @@
                 </CollectionView.ItemTemplate>
             </CollectionView>
             <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
-                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" />
-                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions}" />
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" IsEnabled="{Binding CanRunTests}" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanRunUntilFailure}" />
             </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>

--- a/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/GroupByClassTestsPage.xaml.cs
@@ -31,6 +31,7 @@ namespace TestAppRunner.Views
             list.ItemsSource = new List<TestResultGroup>(tests.GroupBy(t => t.ClassName).Select((g, t) => new TestResultGroup(g.Key.StartsWith(tests.Group + ".") ? g.Key.Substring(tests.Group.Length + 1) : g.Key, g)).OrderBy(g=>g.Group));
             currentTestView.BindingContext = TestRunnerVM.Instance;
             loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            startStopButton.BindingContext = TestRunnerVM.Instance;
             runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
             this.BindingContext = tests;
         }

--- a/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml
@@ -87,8 +87,8 @@
 
             </ScrollView>
             <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
-                <Button Text="Run Test" Clicked="Button_Clicked" />
-                <Button Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" Clicked="RunUntilFailureButton_Clicked" IsEnabled="{Binding CanInteractWithRunActions}" />
+                <Button Text="Run Test" x:Name="startStopButton" Clicked="Button_Clicked" IsEnabled="{Binding CanRunTests}" />
+                <Button Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" Clicked="RunUntilFailureButton_Clicked" IsEnabled="{Binding CanRunUntilFailure}" />
             </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>

--- a/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/ItemDetailPage.xaml.cs
@@ -30,6 +30,7 @@ namespace TestAppRunner.Views
             this.BindingContext = vm;
             InitializeComponent();
             loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            startStopButton.BindingContext = TestRunnerVM.Instance;
             runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
 		}
 

--- a/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml
+++ b/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml
@@ -67,8 +67,8 @@
                 </CollectionView.ItemTemplate>
             </CollectionView>
             <VerticalStackLayout Grid.Row="2" Spacing="10" Padding="10,0,10,10">
-                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" />
-                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanInteractWithRunActions}" />
+                <Button Clicked="Button_Clicked" Text="Run tests" x:Name="startStopButton" IsEnabled="{Binding CanRunTests}" />
+                <Button Clicked="RunUntilFailureButton_Clicked" Text="{Binding RunUntilFailureActionText}" x:Name="runUntilFailureButton" IsEnabled="{Binding CanRunUntilFailure}" />
             </VerticalStackLayout>
         </Grid>
     </ContentPage.Content>

--- a/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml.cs
+++ b/src/TestAppRunner/TestAppRunner/Views/TestRunPage.xaml.cs
@@ -14,6 +14,7 @@ namespace TestAppRunner.Views
 			InitializeComponent();
             currentTestView.BindingContext = TestRunnerVM.Instance;
             loopIterationLabel.BindingContext = TestRunnerVM.Instance;
+            startStopButton.BindingContext = TestRunnerVM.Instance;
             runUntilFailureButton.BindingContext = TestRunnerVM.Instance;
             this.BindingContext = testCases;
         }


### PR DESCRIPTION
The run controls had two issues. During a normal run, the Run until
failure button became disabled but also changed its label to Stop,
which incorrectly suggested loop cancellation was active. The Run
button could also remain enabled on nested pages because its enabled
binding was evaluated against the page data context instead of
TestRunnerVM.

Fix the shared action state in TestRunnerVM by separating the enabled
state for the Run and Run until failure buttons, and by using the
active cancellation token source to mark the UI busy as soon as a run
starts. Keep the Stop label exclusive to the looping flow, so a normal
run leaves the Run until failure label unchanged while disabling it.

Bind the Run button to TestRunnerVM on the grouped and detail pages so
CanRunTests updates correctly everywhere in the UI.
